### PR TITLE
Add loading state, update NewsList styling and other small fixes

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -50,7 +50,7 @@ const App = () => {
         <Switch>
           {/* Route to the Landing page */}
           <Route key={firstPageName} exact path={`/`}>
-            <div>{firsPageComponentName}</div>
+            <div className="Wrapper">{firsPageComponentName}</div>
           </Route>
 
           {/* Dynamically render route link in the Navbar 
@@ -60,7 +60,7 @@ const App = () => {
             let { componentName } = page;
             return (
               <Route key={name} path={`/${name}`}>
-                <div>{componentName}</div>
+                <div className="Wrapper">{componentName}</div>
               </Route>
             );
           })}

--- a/src/components/News.js
+++ b/src/components/News.js
@@ -1,10 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import news from '../apis/news';
 import Section from './Section';
+import NewsList from './NewsList';
+
+import '../styles/News.css';
 
 const News = () => {
   // State
   const [articles, setArticles] = useState({ articles: [] });
+  const [loaded, setLoaded] = useState(false)
 
   // Could also think about a caching stategy? Where we cache the response?
   useEffect(() => {
@@ -13,6 +17,7 @@ const News = () => {
         const response = await news.get();
         if (response.status === 200) {
           setArticles(response.data.articles);
+          setLoaded(true);
         } else {
           setArticles('Ops something went wrong');
         }
@@ -23,40 +28,17 @@ const News = () => {
     fetchData();
   }, []);
 
-  // Could maybe extract this into its own List/Card component?
   const newsList = () => {
-    if (articles.length > 0) {
-      return (
-        <div className="News-Headline-Container">
-          <ul className="News-Headline-List">
-            {articles.map(article => {
-              // publishedAt seems to be th only unquie id. Should be okay for now.
-              return (
-                <li key={article.publishedAt}>
-                  <div className="ui card">
-                    <a href={article.url}>
-                      <img
-                        className="Acticle-Image"
-                        src={article.urlToImage}
-                        alt={article.title}
-                      />
-                    </a>
-                    <div className="content">
-                      <a className="header" href={article.url}>
-                        {article.title}
-                      </a>
-                    </div>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      );
-    }
-  };
+    console.log(articles);
+    return <NewsList articles={articles} />;
+  }
 
-  return <Section newsList={newsList} />;
+
+  return (
+    <>
+      {loaded ? <Section newsList={newsList} /> : <div className="Loading">Loading...</div>}
+    </>
+  );
 };
 
 export default News;

--- a/src/components/News.js
+++ b/src/components/News.js
@@ -29,7 +29,6 @@ const News = () => {
   }, []);
 
   const newsList = () => {
-    console.log(articles);
     return <NewsList articles={articles} />;
   }
 

--- a/src/components/NewsList.js
+++ b/src/components/NewsList.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import '../styles/NewsList.css';
+
+const NewsList = props => {
+
+    const { articles } = props;
+
+    if (articles.length > 0) {
+        return (
+            <div className="News-Headline-Container">
+                <ul className="News-Headline-List">
+                    {articles.map((article, index) => {
+                        return (
+                            <li key={index} className="News-Headline-List-Items">
+                                <div className="ui card">
+                                    <a href={article.url}>
+                                        <img
+                                            className="Article-Image"
+                                            src={article.urlToImage}
+                                            alt={article.title}
+                                        />
+                                    </a>
+                                    <div className="content">
+                                        <a className="header" href={article.url}>
+                                            {article.title}
+                                        </a>
+                                    </div>
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        );
+    }
+};
+
+export default NewsList;

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,5 +1,8 @@
 .App {
     height: 100vh;
-    overflow: hidden;
     font-family: Poppins, sans-serif;
+}
+
+.Wrapper{
+    margin-top: 100px;
 }

--- a/src/styles/LandingPage.css
+++ b/src/styles/LandingPage.css
@@ -2,11 +2,11 @@
   position: relative;
   display: flex;
   justify-content: center;
-  top: 250px;
+  top: 200px;
+  margin-top: -100px;
 }
 
 .aussieImageWrapper img {
     height: auto;
-    width: 400px;
-    
+    width: 400px;       
 }

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -3,8 +3,10 @@
   width: 100%;
   background: rgba(0, 0, 0, 0.5);
   justify-content: space-between;
+  height: 70px;
   position: fixed;
   top: 0;
+  z-index: 10;
 }
 
 .Navbar-Logo {

--- a/src/styles/News.css
+++ b/src/styles/News.css
@@ -1,0 +1,5 @@
+.Loading{
+    text-align: center;
+    font-size: 2em;
+    font-weight: bold;
+}

--- a/src/styles/NewsList.css
+++ b/src/styles/NewsList.css
@@ -1,0 +1,38 @@
+.News-Headline-List{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+
+.News-Headline-Container {
+    text-align: center;
+    margin-top: 2em;
+    overflow-y: scroll;
+  }
+
+  
+  .Article-Image {
+    width: 275px;
+    height: 165px;
+  }
+
+  .ui.card {
+    margin-bottom: 2em!important;
+    display: flex;
+    flex-direction: column;
+
+  }
+
+a.header{
+    line-height: 1.5em;
+    height: 4em;    
+    overflow: hidden; 
+    padding: 0 20px;
+}
+
+
+

--- a/src/styles/Section.css
+++ b/src/styles/Section.css
@@ -9,28 +9,6 @@
 }
 
 h1.Section-Title {
-  /* Just styling like this for now to avoid it getting stuck behind the logo link */
   text-align: center;
-  padding-top: 8%;
 }
 
-.News-Headline-Container {
-  /* Just styling like this for now */
-  position: relative;
-  text-align: center;
-  top: 10%;
-}
-
-.News-Headline-List {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  grid-gap: 0 10px;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.Acticle-Image {
-  width: 250px;
-  grid-row-end: span 2;
-}


### PR DESCRIPTION
- Created a Loading state which will show the loading text when the api is calling the news articles, avoids a blank screen for users when their internet is slow and let's them know the website is working. 

- Updated the style of the NewsList, we can fix it in another time if needed but I opted to use flexbox instead of grid because grid is more so used when you know the exact layout you want i.e with overlapping elements or different sizes. Flexbox is perfect for what we need, to dynamically render out x amount of news article components and it is all responsive on mobile!

